### PR TITLE
Possible fix to windows builds

### DIFF
--- a/program_info/pollymc.manifest.in
+++ b/program_info/pollymc.manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <assemblyIdentity name="PollyMC.Application.1" type="win32" version="@Launcher_RELEASE_VERSION_NAME4@" />
+  <assemblyIdentity name="PollyMC.Application.1" type="win32" version="@Launcher_VERSION_NAME4@" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>


### PR DESCRIPTION
Error logs show:
ERROR: Line 3: The value of attribute version in element assemblyIdentity is invalid. this should fix it, as i copied the value from prismlauncher.